### PR TITLE
#18 add block visualizer plugin and tests

### DIFF
--- a/block-visualizer/graph/block_plugin/__init__.py
+++ b/block-visualizer/graph/block_plugin/__init__.py
@@ -1,0 +1,5 @@
+"""Block visualizer plugin for graph visualization."""
+
+from .visualizer import BlockVisualizer
+
+__all__ = ["BlockVisualizer"]

--- a/block-visualizer/graph/block_plugin/renderer.py
+++ b/block-visualizer/graph/block_plugin/renderer.py
@@ -1,0 +1,236 @@
+import math
+import random
+from typing import Dict, Tuple
+from graph.api.model.graph import Graph
+from graph.api.model.node import Node
+
+
+# Block dimensions
+BLOCK_W = 160
+BLOCK_H_BASE = 40   # header height
+BLOCK_ROW_H = 18    # height per attribute row
+BLOCK_PAD = 8       # internal padding
+
+
+def _block_height(node: Node) -> int:
+    return BLOCK_H_BASE + max(1, len(node.attributes)) * BLOCK_ROW_H + BLOCK_PAD
+
+
+class BlockRenderer:
+    """Renders graph as SVG where each node is a block/rectangle with attributes."""
+
+    def render(self, graph: Graph, width: int, height: int, layout: str = "force") -> str:
+        positions = self._layout(graph, width, height, layout)
+        return self._build_svg(graph, positions, width, height)
+
+    # ------------------------------------------------------------------
+    # Layouts
+    # ------------------------------------------------------------------
+
+    def _layout(self, graph: Graph, width: int, height: int, layout: str) -> Dict[str, Tuple[float, float]]:
+        if layout == "circle":
+            return self._layout_circle(graph, width, height)
+        elif layout == "grid":
+            return self._layout_grid(graph, width, height)
+        else:
+            return self._layout_force(graph, width, height)
+
+    def _layout_circle(self, graph: Graph, width: int, height: int) -> Dict[str, Tuple[float, float]]:
+        positions: Dict[str, Tuple[float, float]] = {}
+        nodes = graph.nodes
+        n = len(nodes)
+        if n == 0:
+            return positions
+        cx, cy = width / 2, height / 2
+        r = min(width, height) / 2 - BLOCK_W // 2 - 20
+        for i, node in enumerate(nodes):
+            angle = 2 * math.pi * i / n
+            positions[node.id] = (cx + r * math.cos(angle), cy + r * math.sin(angle))
+        return positions
+
+    def _layout_grid(self, graph: Graph, width: int, height: int) -> Dict[str, Tuple[float, float]]:
+        positions: Dict[str, Tuple[float, float]] = {}
+        nodes = graph.nodes
+        n = len(nodes)
+        if n == 0:
+            return positions
+        cols = max(1, int(math.ceil(math.sqrt(n))))
+        rows = int(math.ceil(n / cols))
+        sx = width / (cols + 1)
+        sy = height / (rows + 1)
+        for i, node in enumerate(nodes):
+            positions[node.id] = (sx * (i % cols + 1), sy * (i // cols + 1))
+        return positions
+
+    def _layout_force(self, graph: Graph, width: int, height: int, iterations: int = 120) -> Dict[str, Tuple[float, float]]:
+        positions: Dict[str, Tuple[float, float]] = {}
+        nodes = graph.nodes
+        if not nodes:
+            return positions
+
+        for node in nodes:
+            positions[node.id] = (
+                random.uniform(BLOCK_W, width - BLOCK_W),
+                random.uniform(BLOCK_H_BASE, height - BLOCK_H_BASE),
+            )
+
+        area = width * height
+        k = math.sqrt(area / len(nodes))
+        temp = width / 10
+
+        for _ in range(iterations):
+            forces = {node.id: [0.0, 0.0] for node in nodes}
+
+            # repulsion
+            for i, n1 in enumerate(nodes):
+                for n2 in nodes[i + 1:]:
+                    dx = positions[n2.id][0] - positions[n1.id][0]
+                    dy = positions[n2.id][1] - positions[n1.id][1]
+                    dist = math.sqrt(dx * dx + dy * dy) + 0.01
+                    f = (k * k) / dist
+                    fx, fy = f * dx / dist, f * dy / dist
+                    forces[n1.id][0] -= fx
+                    forces[n1.id][1] -= fy
+                    forces[n2.id][0] += fx
+                    forces[n2.id][1] += fy
+
+            # attraction
+            for edge in graph.edges:
+                dx = positions[edge.target.id][0] - positions[edge.source.id][0]
+                dy = positions[edge.target.id][1] - positions[edge.source.id][1]
+                dist = math.sqrt(dx * dx + dy * dy) + 0.01
+                f = (dist * dist) / k
+                fx, fy = f * dx / dist, f * dy / dist
+                forces[edge.source.id][0] += fx
+                forces[edge.source.id][1] += fy
+                forces[edge.target.id][0] -= fx
+                forces[edge.target.id][1] -= fy
+
+            # move
+            for node in nodes:
+                fx = max(-temp, min(temp, forces[node.id][0]))
+                fy = max(-temp, min(temp, forces[node.id][1]))
+                x = max(BLOCK_W // 2, min(width - BLOCK_W // 2, positions[node.id][0] + fx))
+                y = max(BLOCK_H_BASE, min(height - BLOCK_H_BASE, positions[node.id][1] + fy))
+                positions[node.id] = (x, y)
+
+            temp *= 0.95
+
+        return positions
+
+    # ------------------------------------------------------------------
+    # SVG builder
+    # ------------------------------------------------------------------
+
+    def _build_svg(self, graph: Graph, positions: Dict[str, Tuple[float, float]], width: int, height: int) -> str:
+        parts = [
+            f'<svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg" '
+            f'style="border:1px solid #ccc; background:#fafafa;">',
+            '<defs>',
+            '  <style>',
+            '    .blk-header { font: bold 12px monospace; fill: #fff; }',
+            '    .blk-attr-key { font: 11px monospace; fill: #555; }',
+            '    .blk-attr-val { font: 11px monospace; fill: #111; }',
+            '    .blk-divider { stroke: #c0c8d0; stroke-width: 1; }',
+            '  </style>',
+            '</defs>',
+        ]
+
+        # edges first
+        for edge in graph.edges:
+            sx, sy = positions[edge.source.id]
+            tx, ty = positions[edge.target.id]
+            parts.append(
+                f'<line x1="{sx:.1f}" y1="{sy:.1f}" x2="{tx:.1f}" y2="{ty:.1f}" '
+                f'stroke="#aaa" stroke-width="1.5"/>'
+            )
+            if graph.directed:
+                parts.append(self._arrowhead(sx, sy, tx, ty))
+            if edge.label:
+                mx, my = (sx + tx) / 2, (sy + ty) / 2
+                parts.append(
+                    f'<text x="{mx:.1f}" y="{my - 4:.1f}" '
+                    f'font-size="10" fill="#888" text-anchor="middle">{edge.label}</text>'
+                )
+
+        # nodes
+        for node in graph.nodes:
+            cx, cy = positions[node.id]
+            bh = _block_height(node)
+            x = cx - BLOCK_W / 2
+            y = cy - bh / 2
+
+            # outer rect
+            parts.append(
+                f'<rect x="{x:.1f}" y="{y:.1f}" width="{BLOCK_W}" height="{bh}" '
+                f'rx="6" ry="6" fill="#ffffff" stroke="#5b8fa8" stroke-width="1.5"/>'
+            )
+            # header bg
+            parts.append(
+                f'<rect x="{x:.1f}" y="{y:.1f}" width="{BLOCK_W}" height="{BLOCK_H_BASE}" '
+                f'rx="6" ry="6" fill="#5b8fa8"/>'
+            )
+            # cover bottom-round of header
+            parts.append(
+                f'<rect x="{x:.1f}" y="{y + BLOCK_H_BASE / 2:.1f}" width="{BLOCK_W}" height="{BLOCK_H_BASE / 2:.1f}" '
+                f'fill="#5b8fa8"/>'
+            )
+            # node id in header
+            parts.append(
+                f'<text x="{cx:.1f}" y="{y + BLOCK_H_BASE / 2:.1f}" '
+                f'class="blk-header" text-anchor="middle" dominant-baseline="middle">'
+                f'{node.id}</text>'
+            )
+            # divider
+            dy_div = y + BLOCK_H_BASE
+            parts.append(
+                f'<line x1="{x:.1f}" y1="{dy_div:.1f}" x2="{x + BLOCK_W:.1f}" y2="{dy_div:.1f}" '
+                f'class="blk-divider"/>'
+            )
+
+            # attributes
+            attrs = node.attributes
+            if attrs:
+                for i, (k, v) in enumerate(attrs.items()):
+                    row_y = dy_div + BLOCK_ROW_H * i + BLOCK_ROW_H / 2
+                    # key
+                    parts.append(
+                        f'<text x="{x + 6:.1f}" y="{row_y:.1f}" '
+                        f'class="blk-attr-key" dominant-baseline="middle">{k}:</text>'
+                    )
+                    # value (truncate if too long)
+                    val_str = str(v.value)
+                    if len(val_str) > 12:
+                        val_str = val_str[:11] + "…"
+                    parts.append(
+                        f'<text x="{x + BLOCK_W - 6:.1f}" y="{row_y:.1f}" '
+                        f'class="blk-attr-val" text-anchor="end" dominant-baseline="middle">{val_str}</text>'
+                    )
+            else:
+                row_y = dy_div + BLOCK_ROW_H / 2
+                parts.append(
+                    f'<text x="{cx:.1f}" y="{row_y:.1f}" '
+                    f'font-size="10" fill="#bbb" text-anchor="middle" dominant-baseline="middle">'
+                    f'(no attributes)</text>'
+                )
+
+        parts.append("</svg>")
+        return "\n".join(parts)
+
+    @staticmethod
+    def _arrowhead(x1: float, y1: float, x2: float, y2: float) -> str:
+        dx, dy = x2 - x1, y2 - y1
+        dist = math.sqrt(dx * dx + dy * dy) + 0.01
+        nx, ny = dx / dist, dy / dist
+        tip_x = x2 - nx * (BLOCK_W / 2 + 4)
+        tip_y = y2 - ny * (BLOCK_H_BASE / 2 + 4)
+        angle = math.atan2(dy, dx)
+        size, spread = 10, math.pi / 6
+        p1x = tip_x - size * math.cos(angle - spread)
+        p1y = tip_y - size * math.sin(angle - spread)
+        p2x = tip_x - size * math.cos(angle + spread)
+        p2y = tip_y - size * math.sin(angle + spread)
+        return (
+            f'<polygon points="{tip_x:.1f},{tip_y:.1f} {p1x:.1f},{p1y:.1f} {p2x:.1f},{p2y:.1f}" '
+            f'fill="#555"/>'
+        )

--- a/block-visualizer/graph/block_plugin/visualizer.py
+++ b/block-visualizer/graph/block_plugin/visualizer.py
@@ -1,0 +1,47 @@
+from graph.api.services.plugin import VisualizerPlugin
+from graph.api.model.graph import Graph
+from .renderer import BlockRenderer
+
+
+class BlockVisualizer(VisualizerPlugin):
+    """
+    Block visualizer plugin — renders each node as a rectangle
+    showing the node ID in a header and all attributes as key/value rows.
+    """
+
+    def __init__(self):
+        self.__renderer = BlockRenderer()
+
+    def name(self) -> str:
+        return "Block Visualizer"
+
+    def identifier(self) -> str:
+        return "block"
+
+    def visualize(self, graph: Graph, **kwargs) -> str:
+        """
+        Visualize the graph as an SVG string with block-style nodes.
+
+        kwargs:
+            width  (int): canvas width  (default 900)
+            height (int): canvas height (default 700)
+            layout (str): 'force' | 'circle' | 'grid'  (default 'force')
+
+        Returns:
+            SVG string
+        """
+        if not isinstance(graph, Graph):
+            raise TypeError("graph must be a Graph instance")
+
+        width = kwargs.get("width", 900)
+        height = kwargs.get("height", 700)
+        layout = kwargs.get("layout", "force")
+
+        if not isinstance(width, int) or width <= 0:
+            raise ValueError("width must be a positive integer")
+        if not isinstance(height, int) or height <= 0:
+            raise ValueError("height must be a positive integer")
+        if layout not in ("force", "circle", "grid"):
+            raise ValueError("layout must be 'force', 'circle', or 'grid'")
+
+        return self.__renderer.render(graph, width=width, height=height, layout=layout)

--- a/block-visualizer/pyproject.toml
+++ b/block-visualizer/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "graph-block-visualizer"
+version = "0.1"
+dependencies = ["graph-api==0.1"]
+
+[project.entry-points."graph.visualizer"]
+block = "graph.block_plugin.visualizer:BlockVisualizer"
+
+[tool.setuptools]
+provides = ["graph"]

--- a/install.bat
+++ b/install.bat
@@ -22,6 +22,7 @@ pip install -e .\api
 pip install -e .\platform
 pip install -e .\json-plugin
 pip install -e .\simple-visualizer
+pip install -e .\block-visualizer
 pip install -e .\csv-plugin
 pip install django
 
@@ -47,6 +48,12 @@ echo ================================
 echo Running Simple Visualizer tests...
 echo ================================
 python -m tests.test_simple_visualizer
+
+echo.
+echo ================================
+echo Running Block Visualizer tests...
+echo ================================
+python -m tests.test_block_visualizer
 
 echo.
 echo ================================

--- a/tests/test_block_visualizer.py
+++ b/tests/test_block_visualizer.py
@@ -1,0 +1,267 @@
+import random
+from pathlib import Path
+
+from graph.api.model.graph import Graph
+from graph.api.model.node import Node
+from graph.api.model.attributes import AttributeValue, AttributeType
+from graph.block_plugin.visualizer import BlockVisualizer
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+class BlockVisualizerTestSuite:
+
+    def __init__(self):
+        self.visualizer = BlockVisualizer()
+        self.passed = 0
+        self.failed = 0
+
+    def save_svg(self, filename: str, svg: str) -> str:
+        filepath = OUTPUT_DIR / filename
+        with open(filepath, "w") as f:
+            f.write(svg)
+        return str(filepath)
+
+    # ------------------------------------------------------------------
+
+    def test_directed_graph(self):
+        """Test 1: Basic directed graph."""
+        try:
+            g = Graph(directed=True, cyclic=True)
+            nodes = [Node(name) for name in ["Alice", "Bob", "Charlie"]]
+            for n in nodes:
+                g.add_node(n)
+            g.add_edge(nodes[0], nodes[1], label="knows")
+            g.add_edge(nodes[1], nodes[2], label="works_with")
+            g.add_edge(nodes[2], nodes[0], label="respects")
+
+            svg = self.visualizer.visualize(g, width=800, height=600)
+            self.save_svg("blk_01_directed.svg", svg)
+
+            assert "<rect" in svg, "Expected rect elements"
+            assert "Alice" in svg
+            print("✓ Test 1 PASSED: Directed graph")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 1 FAILED: {e}")
+            self.failed += 1
+
+    def test_undirected_graph(self):
+        """Test 2: Undirected graph, circle layout."""
+        try:
+            g = Graph(directed=False, cyclic=True)
+            nodes = [Node(f"N{i}") for i in range(5)]
+            for n in nodes:
+                g.add_node(n)
+            for i in range(5):
+                g.add_edge(nodes[i], nodes[(i + 1) % 5])
+
+            svg = self.visualizer.visualize(g, width=800, height=600, layout="circle")
+            self.save_svg("blk_02_undirected_circle.svg", svg)
+
+            assert "<rect" in svg
+            print("✓ Test 2 PASSED: Undirected graph, circle layout")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 2 FAILED: {e}")
+            self.failed += 1
+
+    def test_nodes_with_attributes(self):
+        """Test 3: Nodes with multiple typed attributes."""
+        try:
+            g = Graph(directed=True, cyclic=False)
+
+            alice = Node("Alice")
+            alice.add_attribute("age",  AttributeValue(AttributeType.INT, 30))
+            alice.add_attribute("role", AttributeValue(AttributeType.STR, "Engineer"))
+            alice.add_attribute("score", AttributeValue(AttributeType.FLOAT, 9.5))
+
+            bob = Node("Bob")
+            bob.add_attribute("age",  AttributeValue(AttributeType.INT, 28))
+            bob.add_attribute("role", AttributeValue(AttributeType.STR, "Designer"))
+
+            g.add_node(alice)
+            g.add_node(bob)
+            g.add_edge(alice, bob, label="supervises")
+
+            svg = self.visualizer.visualize(g, width=800, height=600)
+            self.save_svg("blk_03_attributes.svg", svg)
+
+            assert "age" in svg
+            assert "role" in svg
+            assert "Engineer" in svg
+            print("✓ Test 3 PASSED: Nodes with attributes")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 3 FAILED: {e}")
+            self.failed += 1
+
+    def test_grid_layout(self):
+        """Test 4: Grid layout with 9 nodes."""
+        try:
+            g = Graph(directed=True, cyclic=True)
+            nodes = [Node(f"Item_{i}") for i in range(9)]
+            for n in nodes:
+                g.add_node(n)
+            for i in range(8):
+                g.add_edge(nodes[i], nodes[i + 1])
+
+            svg = self.visualizer.visualize(g, width=900, height=900, layout="grid")
+            self.save_svg("blk_04_grid.svg", svg)
+
+            assert svg.count("<rect") >= 9
+            print("✓ Test 4 PASSED: Grid layout, 9 nodes")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 4 FAILED: {e}")
+            self.failed += 1
+
+    def test_force_layout_large(self):
+        """Test 5: Force layout with 20 nodes."""
+        try:
+            g = Graph(directed=True, cyclic=True)
+            nodes = [Node(f"Node_{i:02d}") for i in range(20)]
+            for n in nodes:
+                g.add_node(n)
+
+            random.seed(42)
+            for _ in range(30):
+                src = random.choice(nodes)
+                tgt = random.choice(nodes)
+                if src.id != tgt.id:
+                    try:
+                        g.add_edge(src, tgt)
+                    except ValueError:
+                        pass
+
+            svg = self.visualizer.visualize(g, width=1000, height=1000, layout="force")
+            self.save_svg("blk_05_force_large.svg", svg)
+
+            assert svg.count("<rect") >= 20
+            print(f"✓ Test 5 PASSED: Force layout, {len(g.nodes)} nodes, {len(g.edges)} edges")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 5 FAILED: {e}")
+            self.failed += 1
+
+    def test_empty_graph(self):
+        """Test 6: Empty graph produces valid SVG."""
+        try:
+            g = Graph(directed=True)
+            svg = self.visualizer.visualize(g, width=800, height=600)
+            self.save_svg("blk_06_empty.svg", svg)
+
+            assert "<svg" in svg
+            assert "</svg>" in svg
+            print("✓ Test 6 PASSED: Empty graph")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 6 FAILED: {e}")
+            self.failed += 1
+
+    def test_single_node_no_attributes(self):
+        """Test 7: Single node with no attributes shows placeholder."""
+        try:
+            g = Graph(directed=True)
+            g.add_node(Node("Isolated"))
+
+            svg = self.visualizer.visualize(g, width=800, height=600)
+            self.save_svg("blk_07_single_node.svg", svg)
+
+            assert "Isolated" in svg
+            assert "no attributes" in svg
+            print("✓ Test 7 PASSED: Single node, no attributes")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 7 FAILED: {e}")
+            self.failed += 1
+
+    def test_long_attribute_value_truncated(self):
+        """Test 8: Long attribute values are truncated."""
+        try:
+            g = Graph(directed=True)
+            n = Node("LongVal")
+            n.add_attribute("desc", AttributeValue(AttributeType.STR, "This is a very long value"))
+            g.add_node(n)
+
+            svg = self.visualizer.visualize(g, width=800, height=600)
+            self.save_svg("blk_08_truncated.svg", svg)
+
+            assert "…" in svg, "Expected truncation marker"
+            print("✓ Test 8 PASSED: Long attribute value truncated")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 8 FAILED: {e}")
+            self.failed += 1
+
+    def test_invalid_layout_raises(self):
+        """Test 9: Invalid layout raises ValueError."""
+        try:
+            g = Graph(directed=True)
+            g.add_node(Node("A"))
+            try:
+                self.visualizer.visualize(g, layout="invalid")
+                assert False, "Expected ValueError"
+            except ValueError:
+                pass
+            print("✓ Test 9 PASSED: Invalid layout raises ValueError")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 9 FAILED: {e}")
+            self.failed += 1
+
+    def test_identifier_and_name(self):
+        """Test 10: Plugin identifier and name are correct."""
+        try:
+            assert self.visualizer.identifier() == "block"
+            assert self.visualizer.name() == "Block Visualizer"
+            print("✓ Test 10 PASSED: identifier='block', name='Block Visualizer'")
+            self.passed += 1
+        except Exception as e:
+            print(f"✗ Test 10 FAILED: {e}")
+            self.failed += 1
+
+    # ------------------------------------------------------------------
+
+    def run_all(self):
+        print("\n" + "=" * 70)
+        print("BLOCK VISUALIZER PLUGIN - TEST SUITE")
+        print("=" * 70)
+
+        self.test_directed_graph()
+        self.test_undirected_graph()
+        self.test_nodes_with_attributes()
+        self.test_grid_layout()
+        self.test_force_layout_large()
+        self.test_empty_graph()
+        self.test_single_node_no_attributes()
+        self.test_long_attribute_value_truncated()
+        self.test_invalid_layout_raises()
+        self.test_identifier_and_name()
+
+        print("\n" + "=" * 70)
+        print(f"RESULTS: {self.passed} Passed, {self.failed} Failed")
+        print("=" * 70)
+
+        if self.failed == 0:
+            print("\n✓ ALL TESTS PASSED!")
+        else:
+            print(f"\n✗ {self.failed} test(s) failed")
+
+        print(f"\nOutput SVGs saved to: {OUTPUT_DIR}")
+        for f in sorted(OUTPUT_DIR.glob("blk_*.svg")):
+            print(f"  {f.name}")
+
+        return self.failed == 0
+
+
+def main():
+    suite = BlockVisualizerTestSuite()
+    success = suite.run_all()
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())


### PR DESCRIPTION
Implements the Block Visualizer plugin.

Changes:
- Added BlockRenderer that renders each node as a rectangle with a header and attribute rows
- Added BlockVisualizer plugin with identifier "block"
- Supports force, circle and grid layouts
- Added unit tests covering all layouts, edge cases and attribute rendering

Closes #18