### PR TITLE
#32 add Flask frontend with D3 graph visualization and CLI terminal

### DIFF
--- a/graph-explorer/flask/app.py
+++ b/graph-explorer/flask/app.py
@@ -1,0 +1,114 @@
+import os
+from flask import Flask, render_template, request, jsonify
+from graph.facade.facade import PlatformFacade
+from graph.cli.parser import CLIParser
+
+# Root of the project (graph-visualiser folder)
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+app = Flask(__name__)
+
+# Initialize facade singleton on startup
+facade = PlatformFacade.get_instance()
+
+
+def get_parser() -> CLIParser:
+    return CLIParser(facade)
+
+
+# ------------------------------------------------------------------
+# Pages
+# ------------------------------------------------------------------
+
+@app.route('/')
+def home():
+    datasources = [{"id": p.identifier(), "name": p.name()} for p in facade.get_datasources()]
+    visualizers  = [{"id": p.identifier(), "name": p.name()} for p in facade.get_visualizers()]
+    return render_template('home.html', datasources=datasources, visualizers=visualizers)
+
+
+# ------------------------------------------------------------------
+# API endpoints
+# ------------------------------------------------------------------
+
+@app.route('/api/load', methods=['POST'])
+def api_load():
+    try:
+        body      = request.get_json()
+        plugin_id = body.get('plugin_id', 'json')
+        path      = body.get('path', 'big_250.json')
+        # resolve relative paths from project root
+        if not os.path.isabs(path):
+            path = os.path.join(PROJECT_ROOT, path)
+        directed  = body.get('directed', 'y')
+        graph = facade.load_graph(plugin_id, path=path, direct=directed)
+        return jsonify({
+            'ok': True,
+            'nodes': len(graph.nodes),
+            'edges': len(graph.edges),
+            'directed': graph.directed,
+            'cyclic': graph.cyclic,
+        })
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 400
+
+
+@app.route('/api/visualize', methods=['POST'])
+def api_visualize():
+    try:
+        body   = request.get_json()
+        viz_id = body.get('visualizer_id', 'simple')
+        width  = int(body.get('width', 900))
+        height = int(body.get('height', 700))
+        layout = body.get('layout', 'force')
+        svg = facade.visualize(viz_id, width=width, height=height, layout=layout)
+        return jsonify({'ok': True, 'svg': svg})
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 400
+
+
+@app.route('/api/cli', methods=['POST'])
+def api_cli():
+    try:
+        body    = request.get_json()
+        raw_cmd = body.get('command', '').strip()
+        if not raw_cmd:
+            return jsonify({'ok': True, 'output': ''})
+
+        parser  = get_parser()
+        command = parser.parse(raw_cmd)
+        output  = command.execute()
+
+        graph = facade.get_active_graph()
+        stats = {'nodes': len(graph.nodes), 'edges': len(graph.edges)} if graph else None
+
+        return jsonify({'ok': True, 'output': output, 'stats': stats})
+    except Exception as e:
+        return jsonify({'ok': False, 'output': f'✗ Error: {e}', 'stats': None})
+
+
+@app.route('/api/graph')
+def api_graph():
+    try:
+        graph = facade.get_active_graph()
+        if graph is None:
+            return jsonify({'ok': False, 'error': 'No graph loaded'}), 400
+
+        nodes = [{'id': n.id, 'attributes': {k: str(v.value) for k, v in n.attributes.items()}}
+                 for n in graph.nodes]
+        edges = [{'id': e.id, 'source': e.source.id, 'target': e.target.id, 'label': e.label}
+                 for e in graph.edges]
+
+        return jsonify({
+            'ok': True,
+            'nodes': nodes,
+            'edges': edges,
+            'directed': graph.directed,
+            'cyclic': graph.cyclic,
+        })
+    except Exception as e:
+        return jsonify({'ok': False, 'error': str(e)}), 400
+
+
+if __name__ == '__main__':
+    app.run(debug=True, port=5000)

--- a/graph-explorer/flask/static/styles.css
+++ b/graph-explorer/flask/static/styles.css
@@ -1,0 +1,406 @@
+:root {
+    --bg:          #1e1e1e;
+    --surface:     #252526;
+    --surface-2:   #2d2d30;
+    --surface-3:   #3c3c3c;
+    --border:      #3c3c3c;
+    --ink:         #d4d4d4;
+    --muted:       #858585;
+    --accent:      #007acc;
+    --accent-2:    #569cd6;
+    --accent-3:    #4ec9b0;
+    --yellow:      #dcdcaa;
+    --green:       #6a9955;
+    --red:         #f44747;
+    --orange:      #ce9178;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: "Segoe UI", system-ui, sans-serif;
+    font-size: 13px;
+    background: var(--bg);
+    color: var(--ink);
+    min-height: 100vh;
+}
+
+/* ── Activity bar (left strip) ───────────────────────────────────── */
+.site-shell {
+    display: grid;
+    grid-template-rows: 30px 1fr;
+    grid-template-columns: 1fr;
+    min-height: 100vh;
+}
+
+/* ── Title bar ───────────────────────────────────────────────────── */
+.navbar {
+    background: #323233;
+    border-bottom: 1px solid #111;
+    display: flex;
+    align-items: center;
+    padding: 0;
+    user-select: none;
+    -webkit-app-region: drag;
+    grid-row: 1;
+}
+
+.nav-inner {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    height: 30px;
+}
+
+.brand {
+    font-size: 12px;
+    font-weight: 400;
+    color: #cccccc;
+    text-decoration: none;
+    padding: 0 12px;
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    height: 100%;
+}
+
+.nav-link {
+    text-decoration: none;
+    color: var(--muted);
+    font-size: 12px;
+    padding: 0 10px;
+    display: flex;
+    align-items: center;
+    border-bottom: 2px solid transparent;
+    transition: color 0.1s;
+}
+
+.nav-link:hover { color: var(--ink); background: #3c3c3c; }
+.nav-link.active {
+    color: var(--ink);
+    border-bottom-color: var(--accent);
+}
+
+.selection-pill {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--muted);
+    padding: 0 12px;
+    white-space: nowrap;
+    font-family: "Consolas", monospace;
+}
+
+/* ── Main layout ─────────────────────────────────────────────────── */
+main {
+    grid-row: 2;
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    grid-template-rows: 1fr;
+    overflow: hidden;
+    height: calc(100vh - 30px);
+}
+
+/* ── Sidebar (left panel) ────────────────────────────────────────── */
+.sidebar {
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.sidebar-section {
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px solid var(--border);
+    min-height: 0;
+}
+
+.sidebar-section.grow { flex: 1; overflow: hidden; }
+
+.sidebar-header {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    padding: 8px 12px 4px;
+    flex-shrink: 0;
+}
+
+/* ── Load panel ──────────────────────────────────────────────────── */
+.load-panel {
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.load-field { display: flex; flex-direction: column; gap: 3px; }
+
+.load-label {
+    font-size: 11px;
+    color: var(--muted);
+}
+
+.vsc-input, .vsc-select {
+    background: var(--surface-3);
+    border: 1px solid var(--border);
+    color: var(--ink);
+    font-size: 12px;
+    padding: 4px 6px;
+    border-radius: 2px;
+    font-family: inherit;
+    width: 100%;
+    outline: none;
+}
+
+.vsc-input:focus, .vsc-select:focus {
+    border-color: var(--accent);
+    outline: 1px solid var(--accent);
+}
+
+.vsc-btn {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    padding: 5px 10px;
+    font-size: 12px;
+    font-family: inherit;
+    border-radius: 2px;
+    cursor: pointer;
+    width: 100%;
+    margin-top: 2px;
+}
+
+.vsc-btn:hover { background: #1a8ad4; }
+.vsc-btn.secondary {
+    background: var(--surface-3);
+    color: var(--ink);
+    border: 1px solid var(--border);
+}
+.vsc-btn.secondary:hover { background: #4c4c4c; }
+
+.load-status {
+    font-size: 11px;
+    font-family: "Consolas", monospace;
+    color: var(--accent-3);
+    min-height: 16px;
+    padding: 0 2px;
+}
+.load-status.error { color: var(--red); }
+
+/* ── View mode tabs ──────────────────────────────────────────────── */
+.view-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-2);
+}
+
+.view-tab {
+    flex: 1;
+    padding: 6px 8px;
+    font-size: 12px;
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    font-family: inherit;
+}
+.view-tab:hover { color: var(--ink); background: var(--surface-3); }
+.view-tab.is-active {
+    color: var(--ink);
+    border-bottom-color: var(--accent);
+    background: var(--surface);
+}
+
+/* ── Search & filter ─────────────────────────────────────────────── */
+.filter-panel {
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.filter-row-inline {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.filter-row-inline .vsc-input { flex: 1; }
+.filter-row-inline .vsc-select { width: 58px; flex-shrink: 0; }
+.filter-row-inline .vsc-btn { width: auto; padding: 4px 8px; margin-top: 0; }
+
+/* ── Tree view ───────────────────────────────────────────────────── */
+#tree-canvas {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: auto;
+    background: var(--surface);
+    font-family: "Consolas", monospace;
+    font-size: 12px;
+}
+
+#tree-canvas svg { display: block; }
+
+/* ── Right panel ─────────────────────────────────────────────────── */
+.right-panel {
+    display: grid;
+    grid-template-rows: 1fr 180px;
+    overflow: hidden;
+}
+
+/* ── Graph area ──────────────────────────────────────────────────── */
+.graph-area {
+    display: grid;
+    grid-template-columns: 1fr 220px;
+    overflow: hidden;
+    border-bottom: 1px solid var(--border);
+}
+
+.main-view-wrap {
+    background: #1a1a1a;
+    overflow: hidden;
+    position: relative;
+}
+
+.panel-header {
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 28px;
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    gap: 8px;
+    z-index: 2;
+    font-size: 12px;
+}
+
+.panel-title { color: var(--ink); font-weight: 600; }
+.panel-caption { color: var(--muted); font-size: 11px; margin-left: auto; }
+
+#main-canvas {
+    position: absolute;
+    top: 28px; left: 0; right: 0; bottom: 0;
+}
+
+/* ── Bird view ───────────────────────────────────────────────────── */
+.bird-wrap {
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.bird-header {
+    height: 28px;
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    font-size: 12px;
+    color: var(--ink);
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+#bird-canvas {
+    flex: 1;
+    overflow: hidden;
+}
+
+/* ── Terminal ────────────────────────────────────────────────────── */
+.terminal-wrap {
+    background: #0e0e0e;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.terminal-tabs {
+    height: 28px;
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.terminal-tab {
+    font-size: 12px;
+    color: var(--ink);
+    padding: 2px 10px;
+    border-bottom: 2px solid var(--accent);
+}
+
+#terminal-output {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px 12px;
+    font-family: "Consolas", monospace;
+    font-size: 12px;
+    line-height: 1.6;
+}
+
+.terminal-line { white-space: pre-wrap; word-break: break-all; }
+.terminal-cmd  { color: #569cd6; }
+.terminal-ok   { color: #d4d4d4; }
+.terminal-err  { color: #f44747; }
+
+.terminal-input-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.terminal-prompt {
+    color: var(--accent-3);
+    font-family: "Consolas", monospace;
+    font-size: 12px;
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.terminal-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: #d4d4d4;
+    font-family: "Consolas", monospace;
+    font-size: 12px;
+    outline: none;
+    caret-color: var(--accent-3);
+}
+
+.terminal-run-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 2px;
+    cursor: pointer;
+    font-family: inherit;
+}
+.terminal-run-btn:hover { background: var(--surface-3); color: var(--ink); }
+
+/* ── Scrollbars ──────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: var(--surface); }
+::-webkit-scrollbar-thumb { background: #424242; border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #555; }

--- a/graph-explorer/flask/templates/base.html
+++ b/graph-explorer/flask/templates/base.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Graph Explorer{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Syne:wght@500;700;800&family=Manrope:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    <div class="site-shell">
+        <nav class="navbar" aria-label="Main navigation">
+            <div class="nav-inner">
+                <a class="brand" href="{{ url_for('home') }}">Graph Explorer</a>
+                <div class="nav-links">
+                    <a class="nav-link active" href="{{ url_for('home') }}">Workspace</a>
+                    <a class="nav-link" href="#main-view">Main View</a>
+                </div>
+                <div class="selection-pill" id="selection-status">Focused Node: —</div>
+            </div>
+        </nav>
+        <main>
+            {% block content %}{% endblock %}
+        </main>
+    </div>
+    {% block extra_scripts %}{% endblock %}
+</body>
+</html>

--- a/graph-explorer/flask/templates/home.html
+++ b/graph-explorer/flask/templates/home.html
@@ -1,0 +1,335 @@
+{% extends "base.html" %}
+
+{% block title %}Home | Graph Explorer{% endblock %}
+
+{% block content %}
+<div style="display:contents">
+
+{# ── Sidebar ──────────────────────────────────────────────────────── #}
+<aside class="sidebar">
+
+    {# Load panel #}
+    <div class="sidebar-section">
+        <div class="sidebar-header">Explorer</div>
+        <div class="load-panel">
+            <div class="load-field">
+                <label class="load-label">Data Source</label>
+                <select id="plugin-select" class="vsc-select">
+                    {% for ds in datasources %}
+                    <option value="{{ ds.id }}">{{ ds.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="load-field">
+                <label class="load-label">File Path</label>
+                <input id="file-path" class="vsc-input" type="text" value="big_250.json" placeholder="e.g. big_250.json">
+            </div>
+            <div class="load-field">
+                <label class="load-label">Directed</label>
+                <select id="directed-select" class="vsc-select">
+                    <option value="y">Yes</option>
+                    <option value="n">No</option>
+                </select>
+            </div>
+            <button class="vsc-btn" onclick="loadGraph()">▶ Load Graph</button>
+            <p id="load-status" class="load-status"></p>
+        </div>
+
+        <div class="view-tabs">
+            <button class="view-tab is-active" onclick="setVisualizer('simple', this)">Simple</button>
+            <button class="view-tab"           onclick="setVisualizer('block',  this)">Block</button>
+        </div>
+    </div>
+
+</aside>
+
+{# ── Right panel ──────────────────────────────────────────────────── #}
+<div class="right-panel">
+
+    {# Graph area #}
+    <div class="graph-area">
+
+        {# Main View #}
+        <div class="main-view-wrap">
+            <div class="panel-header">
+                <span class="panel-title">Main View</span>
+                <span class="panel-caption" id="graph-stats">No graph loaded</span>
+            </div>
+            <div id="main-canvas"></div>
+        </div>
+
+        {# Bird View — placeholder for teammate #}
+        <div class="bird-wrap">
+            <div class="bird-header">Bird View</div>
+            <div id="bird-canvas"></div>
+        </div>
+
+    </div>
+
+    {# Terminal #}
+        <div class="terminal-tabs">
+            <span class="terminal-tab">TERMINAL</span>
+        </div>
+        <div id="terminal-output"></div>
+        <div class="terminal-input-row">
+            <span class="terminal-prompt">❯</span>
+            <input id="terminal-input" class="terminal-input" type="text"
+                   placeholder="Type a command… (help for list)"
+                   onkeydown="if(event.key==='Enter') runCommand()">
+            <button class="terminal-run-btn" onclick="runCommand()">Run</button>
+        </div>
+    </div>
+
+</div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+    let activeVisualizer = 'simple';
+    let selectedNodeId   = null;
+
+    // ── Shared selection ────────────────────────────────────────────
+    function selectNode(id) {
+        selectedNodeId = id;
+        d3.selectAll('#main-canvas circle')
+            .attr('fill', d => d.id === id ? '#f4b942' : '#5b8fa8')
+            .attr('r',    d => d.id === id ? 18 : 14);
+        document.getElementById('selection-status').textContent = `Focused Node: ${id}`;
+    }
+
+    async function loadGraph() {
+        const plugin   = document.getElementById('plugin-select').value;
+        const path     = document.getElementById('file-path').value.trim();
+        const directed = document.getElementById('directed-select').value;
+        const status   = document.getElementById('load-status');
+        status.textContent = 'Loading…';
+        try {
+            const res  = await fetch('/api/load', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({plugin_id: plugin, path, directed})
+            });
+            const data = await res.json();
+            if (data.ok) {
+                status.textContent = `✓ Loaded: ${data.nodes} nodes, ${data.edges} edges`;
+                status.style.color = 'green';
+                await drawGraph();
+            } else {
+                status.textContent = `✗ ${data.error}`;
+                status.style.color = 'red';
+            }
+        } catch(e) {
+            status.textContent = `✗ ${e}`;
+            status.style.color = 'red';
+        }
+    }
+
+    // ── D3 Main View ────────────────────────────────────────────────
+    let simulation   = null;
+    let mainNodes    = [];
+    let mainEdges    = [];
+    let zoomBehavior = null;
+
+    async function drawGraph() {
+        const res  = await fetch('/api/graph');
+        const data = await res.json();
+        if (!data.ok) return;
+
+        mainNodes = data.nodes.map(n => ({...n}));
+        mainEdges = data.edges.map(e => ({...e}));
+
+        const canvas = document.getElementById('main-canvas');
+        const W = canvas.clientWidth  || 900;
+        const H = canvas.clientHeight || 600;
+        canvas.innerHTML = '';
+
+        const svg = d3.select('#main-canvas').append('svg')
+            .attr('width', W).attr('height', H)
+            .style('width', '100%').style('height', '100%');
+
+        const g = svg.append('g');
+
+        zoomBehavior = d3.zoom()
+            .scaleExtent([0.05, 8])
+            .on('zoom', e => {
+                g.attr('transform', e.transform);
+            });
+        svg.call(zoomBehavior);
+
+        svg.append('defs').append('marker')
+            .attr('id', 'arrow').attr('viewBox', '0 -5 10 10')
+            .attr('refX', 22).attr('refY', 0)
+            .attr('markerWidth', 6).attr('markerHeight', 6)
+            .attr('orient', 'auto')
+            .append('path').attr('d', 'M0,-5L10,0L0,5').attr('fill', '#999');
+
+        const link = g.append('g').selectAll('line')
+            .data(mainEdges).enter().append('line')
+            .attr('stroke', '#bbb').attr('stroke-width', 1.5)
+            .attr('marker-end', data.directed ? 'url(#arrow)' : null);
+
+        simulation = d3.forceSimulation(mainNodes)
+            .force('link',   d3.forceLink(mainEdges).id(d => d.id).distance(80))
+            .force('charge', d3.forceManyBody().strength(-200))
+            .force('center', d3.forceCenter(W / 2, H / 2));
+
+        if (activeVisualizer === 'block') {
+            const BWID = 140, BHDR = 32, BROW = 16, BPAD = 6;
+            const bh = d => BHDR + Math.max(1, Object.keys(d.attributes||{}).length) * BROW + BPAD;
+
+            const nodeG = g.append('g').selectAll('.block-node')
+                .data(mainNodes).enter().append('g').attr('class','block-node')
+                .style('cursor','pointer')
+                .call(d3.drag()
+                    .on('start', (e,d) => { if(!e.active) simulation.alphaTarget(0.3).restart(); d.fx=d.x; d.fy=d.y; })
+                    .on('drag',  (e,d) => { d.fx=e.x; d.fy=e.y; })
+                    .on('end',   (e,d) => { if(!e.active) simulation.alphaTarget(0); d.fx=null; d.fy=null; })
+                )
+                .on('click', (e,d) => { e.stopPropagation(); selectNode(d.id); });
+
+            nodeG.append('rect')
+                .attr('width', BWID).attr('rx', 6).attr('ry', 6)
+                .attr('fill', '#fff').attr('stroke', '#5b8fa8').attr('stroke-width', 1.5)
+                .attr('height', d => bh(d));
+            nodeG.append('rect')
+                .attr('width', BWID).attr('height', BHDR).attr('rx', 6).attr('ry', 6)
+                .attr('fill', d => d.id === selectedNodeId ? '#f4b942' : '#5b8fa8');
+            nodeG.append('rect')
+                .attr('width', BWID).attr('height', BHDR/2).attr('y', BHDR/2)
+                .attr('fill', d => d.id === selectedNodeId ? '#f4b942' : '#5b8fa8');
+            nodeG.append('text')
+                .text(d => d.id.length > 14 ? d.id.slice(0,13)+'…' : d.id)
+                .attr('x', BWID/2).attr('y', BHDR/2)
+                .attr('text-anchor','middle').attr('dominant-baseline','middle')
+                .attr('font-size', 11).attr('font-weight','bold').attr('fill','#fff')
+                .style('pointer-events','none');
+            nodeG.append('line')
+                .attr('x1',0).attr('x2', BWID).attr('y1', BHDR).attr('y2', BHDR)
+                .attr('stroke','#c0c8d0');
+            nodeG.each(function(d) {
+                const attrs = Object.entries(d.attributes||{});
+                if (!attrs.length) {
+                    d3.select(this).append('text')
+                        .text('(no attributes)')
+                        .attr('x', BWID/2).attr('y', BHDR + BROW/2)
+                        .attr('text-anchor','middle').attr('dominant-baseline','middle')
+                        .attr('font-size',10).attr('fill','#bbb')
+                        .style('pointer-events','none');
+                } else {
+                    attrs.forEach(([k, v], i) => {
+                        const ry = BHDR + BROW * i + BROW/2;
+                        const valStr = String(v).length > 12 ? String(v).slice(0,11)+'…' : String(v);
+                        d3.select(this).append('text').text(k+':')
+                            .attr('x', 5).attr('y', ry).attr('dominant-baseline','middle')
+                            .attr('font-size',10).attr('fill','#555').style('pointer-events','none');
+                        d3.select(this).append('text').text(valStr)
+                            .attr('x', BWID-5).attr('y', ry).attr('text-anchor','end').attr('dominant-baseline','middle')
+                            .attr('font-size',10).attr('fill','#111').style('pointer-events','none');
+                    });
+                }
+            });
+
+            simulation.on('tick', () => {
+                link.attr('x1', d => d.source.x).attr('y1', d => d.source.y)
+                    .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
+                nodeG.attr('transform', d => `translate(${d.x - BWID/2},${d.y - bh(d)/2})`);
+            });
+
+        } else {
+            const node = g.append('g').selectAll('circle')
+                .data(mainNodes).enter().append('circle')
+                .attr('r', 14)
+                .attr('fill', '#5b8fa8').attr('stroke', '#fff').attr('stroke-width', 2)
+                .style('cursor', 'pointer')
+                .call(d3.drag()
+                    .on('start', (e,d) => { if(!e.active) simulation.alphaTarget(0.3).restart(); d.fx=d.x; d.fy=d.y; })
+                    .on('drag',  (e,d) => { d.fx=e.x; d.fy=e.y; })
+                    .on('end',   (e,d) => { if(!e.active) simulation.alphaTarget(0); d.fx=null; d.fy=null; })
+                )
+                .on('click', (e,d) => { e.stopPropagation(); selectNode(d.id); });
+
+            const label = g.append('g').selectAll('text')
+                .data(mainNodes).enter().append('text')
+                .text(d => d.id).attr('font-size', 10).attr('fill', '#333')
+                .attr('text-anchor', 'middle').attr('dy', 26)
+                .style('pointer-events', 'none');
+
+            simulation.on('tick', () => {
+                link.attr('x1', d => d.source.x).attr('y1', d => d.source.y)
+                    .attr('x2', d => d.target.x).attr('y2', d => d.target.y);
+                node.attr('cx', d => d.x).attr('cy', d => d.y);
+                label.attr('x', d => d.x).attr('y', d => d.y);
+            });
+        }
+
+        document.getElementById('graph-stats').textContent =
+            `${mainNodes.length} nodes · ${mainEdges.length} edges`;
+    }
+
+    function setVisualizer(id, btn) {
+        activeVisualizer = id;
+        document.querySelectorAll('.view-tab').forEach(b => b.classList.remove('is-active'));
+        btn.classList.add('is-active');
+        drawGraph();
+    }
+
+    // ── Terminal ────────────────────────────────────────────────────
+    const history = [];
+    let histIdx = -1;
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const input = document.getElementById('terminal-input');
+        input.addEventListener('keydown', e => {
+            if (e.key === 'ArrowUp') {
+                if (histIdx < history.length - 1) histIdx++;
+                input.value = history[histIdx] || '';
+            } else if (e.key === 'ArrowDown') {
+                if (histIdx > 0) histIdx--;
+                input.value = history[histIdx] || '';
+            }
+        });
+    });
+
+    async function runCommand() {
+        const input = document.getElementById('terminal-input');
+        const cmd = input.value.trim();
+        if (!cmd) return;
+        history.unshift(cmd);
+        histIdx = -1;
+        input.value = '';
+        await runCLI(cmd);
+        if (['create','edit','delete','clear','reset','search','filter']
+            .some(k => cmd.startsWith(k))) {
+            await drawGraph();
+        }
+    }
+
+    async function runCLI(cmd) {
+        const output = document.getElementById('terminal-output');
+        const cmdLine = document.createElement('div');
+        cmdLine.className = 'terminal-line terminal-cmd';
+        cmdLine.textContent = '$ ' + cmd;
+        output.appendChild(cmdLine);
+
+        try {
+            const res  = await fetch('/api/cli', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({command: cmd})
+            });
+            const data = await res.json();
+            const outLine = document.createElement('div');
+            outLine.className = 'terminal-line ' + (data.ok ? 'terminal-ok' : 'terminal-err');
+            outLine.textContent = data.output;
+            output.appendChild(outLine);
+        } catch(e) {
+            const errLine = document.createElement('div');
+            errLine.className = 'terminal-line terminal-err';
+            errLine.textContent = '✗ ' + e;
+            output.appendChild(errLine);
+        }
+        output.scrollTop = output.scrollHeight;
+    }
+</script>
+{% endblock %}

--- a/install.bat
+++ b/install.bat
@@ -26,6 +26,7 @@ pip install -e .\block-visualizer
 pip install -e .\csv-plugin
 pip install -e .\xml-plugin
 pip install django
+pip install flask
 
 echo.
 echo ================================


### PR DESCRIPTION
## Changes
- Added loader panel with datasource select, file path input, directed toggle
- Added Main View with D3 force-directed graph rendering (pan/zoom, node drag, selection highlight)
- Added Simple/Block visualizer mode switching with directed edge arrows
- Added CLI terminal with command history (arrow keys) and auto-refresh on mutating commands
- Left placeholder sections for Search & Filter, Tree View, Bird View
Closes #32