### PR TITLE
#48 Fix workspace management after filter/search operation

### DIFF
--- a/graph-explorer/django/app/static/home.js
+++ b/graph-explorer/django/app/static/home.js
@@ -13,6 +13,14 @@
         ? JSON.parse(defaultPathsElement.textContent)
         : {};
 
+    let currentGraphData = null;
+    let currentSelectedNodeId = null;
+    let currentViewport = null;
+    let currentLayoutPositions = null;
+    let currentLinks = null;
+    let currentMainSize = { width: 760, height: 520 };
+    let currentContentBounds = null;
+
     function applyDefaultsForPlugin(pluginId) {
         const normalized = (pluginId || "").toLowerCase();
 
@@ -48,9 +56,89 @@
         }
     }
 
+    function computeCircularPositions(nodes, width, height) {
+        const nodePositions = new Map();
+
+        if (nodes.length === 1) {
+            nodePositions.set(nodes[0].id, { x: width / 2, y: height / 2 });
+            return nodePositions;
+        }
+
+        const radius = Math.min(width, height) * 0.34;
+        const centerX = width / 2;
+        const centerY = height / 2;
+
+        nodes.forEach((node, index) => {
+            const angle = (2 * Math.PI * index) / nodes.length;
+            const x = centerX + radius * Math.cos(angle);
+            const y = centerY + radius * Math.sin(angle);
+            nodePositions.set(node.id, { x, y });
+        });
+
+        return nodePositions;
+    }
+
+    function computeBoundsFromPositions(positions) {
+        const values = Array.from(positions.values());
+        if (!values.length) return null;
+
+        const minX = Math.min(...values.map(p => p.x));
+        const maxX = Math.max(...values.map(p => p.x));
+        const minY = Math.min(...values.map(p => p.y));
+        const maxY = Math.max(...values.map(p => p.y));
+
+        const pad = 30;
+
+        return {
+            minX: minX - pad,
+            maxX: maxX + pad,
+            minY: minY - pad,
+            maxY: maxY + pad
+        };
+    }
+
+    function buildScaledLayoutPositions(width, height) {
+        if (!currentLayoutPositions || !currentLayoutPositions.size) {
+            return null;
+        }
+
+        const bounds = computeBoundsFromPositions(currentLayoutPositions);
+        currentContentBounds = bounds;
+
+        if (!bounds) return null;
+
+        const contentWidth = Math.max(bounds.maxX - bounds.minX, 1);
+        const contentHeight = Math.max(bounds.maxY - bounds.minY, 1);
+
+        const scale = Math.min(width / contentWidth, height / contentHeight);
+        const scaledWidth = contentWidth * scale;
+        const scaledHeight = contentHeight * scale;
+
+        const offsetX = (width - scaledWidth) / 2;
+        const offsetY = (height - scaledHeight) / 2;
+
+        const result = new Map();
+
+        currentLayoutPositions.forEach((pos, id) => {
+            result.set(id, {
+                x: offsetX + (pos.x - bounds.minX) * scale,
+                y: offsetY + (pos.y - bounds.minY) * scale
+            });
+        });
+
+        return {
+            positions: result,
+            bounds,
+            scale,
+            offsetX,
+            offsetY
+        };
+    }
+
     function renderBirdView(data) {
         if (!birdCanvas) return;
 
+        currentGraphData = data;
         clearContainer(birdCanvas);
 
         const width = birdCanvas.clientWidth || 220;
@@ -61,8 +149,13 @@
             .attr("width", width)
             .attr("height", height);
 
+        const root = svg.append("g").attr("class", "bird-root");
+        const linksLayer = root.append("g").attr("class", "bird-links");
+        const nodesLayer = root.append("g").attr("class", "bird-nodes");
+        const overlayLayer = svg.append("g").attr("class", "bird-overlay");
+
         const nodes = data.nodes || [];
-        const links = data.links || [];
+        const links = currentLinks || data.links || data.edges || [];
 
         if (!nodes.length) {
             svg.append("text")
@@ -74,30 +167,39 @@
             return;
         }
 
-        const radius = Math.min(width, height) * 0.35;
-        const centerX = width / 2;
-        const centerY = height / 2;
-        const nodePositions = new Map();
+        let nodePositions;
+        const scaledLayout = buildScaledLayoutPositions(width, height);
 
-        nodes.forEach((node, index) => {
-            const angle = (2 * Math.PI * index) / Math.max(nodes.length, 1);
-            const x = centerX + radius * Math.cos(angle);
-            const y = centerY + radius * Math.sin(angle);
-            nodePositions.set(node.id, { x, y });
-        });
+        if (scaledLayout && scaledLayout.positions.size) {
+            nodePositions = scaledLayout.positions;
+        } else {
+            nodePositions = computeCircularPositions(nodes, width, height);
+        }
 
-        svg.append("g")
+        linksLayer
             .selectAll("line")
             .data(links)
             .join("line")
-            .attr("x1", d => nodePositions.get(d.source)?.x ?? centerX)
-            .attr("y1", d => nodePositions.get(d.source)?.y ?? centerY)
-            .attr("x2", d => nodePositions.get(d.target)?.x ?? centerX)
-            .attr("y2", d => nodePositions.get(d.target)?.y ?? centerY)
+            .attr("x1", d => {
+                const sourceId = typeof d.source === "object" ? d.source.id : d.source;
+                return nodePositions.get(sourceId)?.x ?? width / 2;
+            })
+            .attr("y1", d => {
+                const sourceId = typeof d.source === "object" ? d.source.id : d.source;
+                return nodePositions.get(sourceId)?.y ?? height / 2;
+            })
+            .attr("x2", d => {
+                const targetId = typeof d.target === "object" ? d.target.id : d.target;
+                return nodePositions.get(targetId)?.x ?? width / 2;
+            })
+            .attr("y2", d => {
+                const targetId = typeof d.target === "object" ? d.target.id : d.target;
+                return nodePositions.get(targetId)?.y ?? height / 2;
+            })
             .attr("stroke", "#aeb8ae")
             .attr("stroke-width", 1);
 
-        const node = svg.append("g")
+        const nodeGroups = nodesLayer
             .selectAll("g")
             .data(nodes)
             .join("g")
@@ -106,17 +208,114 @@
                 return `translate(${p.x},${p.y})`;
             });
 
-        node.append("circle")
-            .attr("r", 6)
-            .attr("fill", "#157a6e");
+        nodeGroups.append("circle")
+            .attr("r", d => d.id === currentSelectedNodeId ? 8 : 6)
+            .attr("fill", d => d.id === currentSelectedNodeId ? "#f4b942" : "#157a6e")
+            .attr("stroke", d => d.id === currentSelectedNodeId ? "#8a5a00" : "none")
+            .attr("stroke-width", d => d.id === currentSelectedNodeId ? 2 : 0);
 
-        node.append("title")
+        nodeGroups.append("title")
             .text(d => d.id);
+
+        if (currentViewport) {
+            overlayLayer.append("rect")
+                .attr("x", currentViewport.x)
+                .attr("y", currentViewport.y)
+                .attr("width", currentViewport.width)
+                .attr("height", currentViewport.height)
+                .attr("fill", "rgba(244,185,66,0.10)")
+                .attr("stroke", "#f4b942")
+                .attr("stroke-width", 2)
+                .attr("rx", 4)
+                .attr("ry", 4);
+        }
+    }
+
+    function updateBirdSelection(nodeId) {
+        currentSelectedNodeId = nodeId || null;
+        if (currentGraphData) {
+            renderBirdView(currentGraphData);
+        }
+    }
+
+    function updateBirdLayout(messageData) {
+        const positions = messageData?.positions || [];
+        currentLinks = messageData?.links || currentLinks;
+
+        if (!positions.length) return;
+
+        const map = new Map();
+        positions.forEach(pos => {
+            if (pos && pos.id != null && pos.x != null && pos.y != null) {
+                map.set(pos.id, { x: Number(pos.x), y: Number(pos.y) });
+            }
+        });
+
+        currentLayoutPositions = map;
+
+        if (currentGraphData) {
+            renderBirdView(currentGraphData);
+        }
+    }
+
+    function updateBirdViewport(messageData) {
+        if (!messageData || !messageData.transform) {
+            currentViewport = null;
+        } else {
+            const transform = messageData.transform;
+            const mainWidth = messageData.width || currentMainSize.width || 760;
+            const mainHeight = messageData.height || currentMainSize.height || 520;
+
+            currentMainSize = {
+                width: mainWidth,
+                height: mainHeight
+            };
+
+            const birdWidth = birdCanvas?.clientWidth || 220;
+            const birdHeight = birdCanvas?.clientHeight || 160;
+
+            const visibleLeft = -transform.x / transform.k;
+            const visibleTop = -transform.y / transform.k;
+            const visibleWidth = mainWidth / transform.k;
+            const visibleHeight = mainHeight / transform.k;
+
+            if (currentLayoutPositions && currentLayoutPositions.size && currentContentBounds) {
+                const scaledLayout = buildScaledLayoutPositions(birdWidth, birdHeight);
+
+                if (scaledLayout) {
+                    const bounds = scaledLayout.bounds;
+                    const scale = scaledLayout.scale;
+                    const offsetX = scaledLayout.offsetX;
+                    const offsetY = scaledLayout.offsetY;
+
+                    currentViewport = {
+                        x: offsetX + (visibleLeft - bounds.minX) * scale,
+                        y: offsetY + (visibleTop - bounds.minY) * scale,
+                        width: visibleWidth * scale,
+                        height: visibleHeight * scale
+                    };
+                } else {
+                    currentViewport = null;
+                }
+            } else {
+                currentViewport = {
+                    x: visibleLeft * (birdWidth / mainWidth),
+                    y: visibleTop * (birdHeight / mainHeight),
+                    width: visibleWidth * (birdWidth / mainWidth),
+                    height: visibleHeight * (birdHeight / mainHeight)
+                };
+            }
+        }
+
+        if (currentGraphData) {
+            renderBirdView(currentGraphData);
+        }
     }
 
     async function renderBirdViewFromBackend() {
         try {
             const data = await loadGraphData();
+            currentLinks = data.links || data.edges || [];
             renderBirdView(data);
         } catch (err) {
             if (birdCanvas) {
@@ -125,11 +324,54 @@
         }
     }
 
+    function handleVisualizerPayload(payload) {
+        if (!payload || typeof payload !== "object") return;
+        if (!payload.type) return;
+
+        if (payload.type === "node-select") {
+            updateBirdSelection(payload.data?.nodeId);
+        }
+
+        if (payload.type === "viewport-change") {
+            updateBirdViewport(payload.data);
+        }
+
+        if (payload.type === "visualizer-positions" || payload.type === "layout-complete") {
+            updateBirdLayout(payload.data);
+        }
+
+        if (payload.type === "graph-ready") {
+            if (payload.data?.width && payload.data?.height) {
+                currentMainSize = {
+                    width: payload.data.width,
+                    height: payload.data.height
+                };
+            }
+            renderBirdViewFromBackend();
+        }
+    }
+
+    function handleVisualizerMessage(event) {
+        handleVisualizerPayload(event.data);
+    }
+
+    function handleInlineVisualizerEvent(event) {
+        handleVisualizerPayload(event.detail);
+    }
+
     if (pluginSelect) {
         pluginSelect.addEventListener("change", (event) => {
             applyDefaultsForPlugin(event.target.value);
         });
     }
+
+    window.addEventListener("message", handleVisualizerMessage);
+    window.addEventListener("visualizer-event", handleInlineVisualizerEvent);
+    window.addEventListener("resize", () => {
+        if (currentGraphData) {
+            renderBirdView(currentGraphData);
+        }
+    });
 
     renderBirdViewFromBackend();
 })();

--- a/graph-explorer/django/app/templates/home.html
+++ b/graph-explorer/django/app/templates/home.html
@@ -9,7 +9,7 @@
 <script>
     const INITIAL_GRAPH = JSON.parse(document.getElementById("initial-graph-data").textContent || "{}");
     const API = {
-        load: "{% url 'load_file' %}",  
+        load: "{% url 'load_file' %}",
         visualize: "{% url 'visualize_graph' %}",
     };
 </script>
@@ -32,7 +32,7 @@
         <div class="alert alert-success">{{ success_message }}</div>
     {% endif %}
 
-    <form method="post" class="load-graph-form">
+    <form method="post" action="{% url 'home' %}" class="load-graph-form">
         {% csrf_token %}
         <input type="hidden" name="action" value="create">
 
@@ -95,7 +95,7 @@
 <section class="card card-gap">
     <h2 class="section-title">Workspace Management</h2>
 
-    <form method="post" class="load-graph-form">
+    <form method="post" action="{% url 'home' %}" class="load-graph-form">
         {% csrf_token %}
 
         <div class="load-grid">

--- a/graph-explorer/django/app/views.py
+++ b/graph-explorer/django/app/views.py
@@ -55,12 +55,12 @@ def _serialize_graph(graph) -> dict:
         }
         for n in graph.nodes
     ]
-    
+
     edges = [
         {
-            "id": e.id, 
-            "source": e.source.id, 
-            "target": e.target.id, 
+            "id": e.id,
+            "source": e.source.id,
+            "target": e.target.id,
             "label": getattr(e, "label", "")
         }
         for e in graph.edges
@@ -69,7 +69,7 @@ def _serialize_graph(graph) -> dict:
     return {
         "nodes": nodes,
         "edges": edges,
-        "links": edges,  
+        "links": edges,
         "directed": graph.directed,
         "cyclic": graph.cyclic,
         "node_count": len(graph.nodes),
@@ -171,18 +171,19 @@ def _build_context(
 
 def _render_home_with_state(request, facade, **kwargs):
     active_ws = _get_active_workspace_name(facade)
+
     context = _build_context(
         facade,
         selected_datasource=DEFAULT_DATASOURCE,
         selected_visualizer=DEFAULT_VISUALIZER,
-        workspace_name=active_ws or DEFAULT_WORKSPACE,
+        workspace_name="",
         selected_workspace=active_ws,
-        path="",
+        path=str(DEFAULT_PATHS.get(DEFAULT_DATASOURCE, DATA_DIR / "sample.json")),
         id_key="@id",
         ref_key="@ref",
         treat_string_refs_as_ids=True,
         directed=False,
-        main_view_html=_render_main_view(facade, DEFAULT_VISUALIZER) if facade.get_active_graph() else ""
+        main_view_html=_render_main_view(facade, DEFAULT_VISUALIZER) if facade.get_active_graph() else "",
     )
     context.update(kwargs)
     return render(request, "home.html", context)
@@ -199,7 +200,7 @@ def home(request):
             "selected_workspace": "",
             "selected_datasource": DEFAULT_DATASOURCE,
             "selected_visualizer": DEFAULT_VISUALIZER,
-            "workspace_name": DEFAULT_WORKSPACE,
+            "workspace_name": "",
             "path": str(DEFAULT_PATHS.get(DEFAULT_DATASOURCE, DATA_DIR / "sample.json")),
             "id_key": "@id",
             "ref_key": "@ref",
@@ -210,13 +211,18 @@ def home(request):
             "success_message": "",
             "default_paths": {k: str(v) for k, v in DEFAULT_PATHS.items()},
             "graph_json": json.dumps(_serialize_graph(None)),
+            "search_text": "",
+            "filter_field": "",
+            "filter_operator": ">",
+            "filter_value": "",
+            "ui_status": "",
         })
 
     facade = _get_facade()
 
     selected_datasource = DEFAULT_DATASOURCE
     selected_visualizer = DEFAULT_VISUALIZER
-    workspace_name = DEFAULT_WORKSPACE
+    workspace_name = ""
     selected_workspace = ""
     path = str(DEFAULT_PATHS.get(DEFAULT_DATASOURCE, DATA_DIR / "sample.json"))
     id_key = "@id"
@@ -239,6 +245,10 @@ def home(request):
                 treat_string_refs_as_ids=True,
                 directed=False,
             )
+            try:
+                facade.switch_workspace(DEFAULT_WORKSPACE)
+            except Exception:
+                pass
         except Exception as e:
             error_message = str(e)
 
@@ -247,7 +257,7 @@ def home(request):
 
         selected_datasource = request.POST.get("plugin_id", DEFAULT_DATASOURCE).strip().lower()
         selected_visualizer = request.POST.get("visualizer_id", DEFAULT_VISUALIZER).strip().lower()
-        workspace_name = request.POST.get("workspace_name", DEFAULT_WORKSPACE).strip() or DEFAULT_WORKSPACE
+        workspace_name = request.POST.get("workspace_name", "").strip()
         selected_workspace = request.POST.get("selected_workspace", "").strip()
         path = request.POST.get("path", "").strip()
         id_key = request.POST.get("id_key", "@id").strip() or "@id"
@@ -257,8 +267,10 @@ def home(request):
 
         try:
             if action == "create":
+                final_workspace_name = workspace_name or DEFAULT_WORKSPACE
+
                 facade.create_workspace(
-                    name=workspace_name,
+                    name=final_workspace_name,
                     plugin_id=selected_datasource,
                     path=path,
                     id_key=id_key,
@@ -266,8 +278,12 @@ def home(request):
                     treat_string_refs_as_ids=treat_string_refs_as_ids,
                     directed=directed,
                 )
-                success_message = f"Workspace '{workspace_name}' created and activated."
-                selected_workspace = workspace_name
+
+                # KLJUCNA IZMENA:
+                facade.switch_workspace(final_workspace_name)
+
+                success_message = f"Workspace '{final_workspace_name}' created and activated."
+                selected_workspace = _get_active_workspace_name(facade)
 
             elif action == "switch":
                 if not selected_workspace:
@@ -288,7 +304,7 @@ def home(request):
                 selected_workspace = _get_active_workspace_name(facade)
 
             else:
-                pass # Unhandled action could be from the filter/search forms
+                pass
 
             if facade.get_active_graph() is not None:
                 main_view_html = _render_main_view(facade, selected_visualizer)
@@ -306,7 +322,6 @@ def home(request):
     current_active = _get_active_workspace_name(facade)
     if current_active:
         selected_workspace = current_active
-        workspace_name = current_active
 
     context = _build_context(
         facade,
@@ -383,7 +398,7 @@ def load_file(request):
                 status=400,
             )
 
-        workspace_name = request.POST.get("workspace_name", DEFAULT_WORKSPACE).strip() or DEFAULT_WORKSPACE
+        workspace_name = request.POST.get("workspace_name", "").strip() or DEFAULT_WORKSPACE
         visualizer_id = request.POST.get("visualizer_id", DEFAULT_VISUALIZER).strip().lower() or DEFAULT_VISUALIZER
 
         id_key = request.POST.get("id_key", "@id").strip() or "@id"
@@ -400,6 +415,11 @@ def load_file(request):
             treat_string_refs_as_ids=treat_string_refs_as_ids,
             directed=directed,
         )
+
+        try:
+            facade.switch_workspace(workspace_name)
+        except Exception:
+            pass
 
         graph = facade.get_active_graph()
         rendered = ""
@@ -500,7 +520,7 @@ def apply_search(request):
             )
 
     try:
-        body  = json.loads(request.body)
+        body = json.loads(request.body)
         query = body.get("query", "").strip()
         if not query:
             return JsonResponse({"error": "query is required"}, status=400)
@@ -556,13 +576,14 @@ def apply_filter(request):
             )
 
     try:
-        body     = json.loads(request.body)
-        field    = body.get("field",    "").strip()
+        body = json.loads(request.body)
+        field = body.get("field", "").strip()
         operator = body.get("operator", "").strip()
-        value    = body.get("value",    "").strip()
+        value = body.get("value", "").strip()
         if not field or not operator or not value:
             return JsonResponse(
-                {"error": "field, operator and value are all required"}, status=400)
+                {"error": "field, operator and value are all required"}, status=400
+            )
         facade = _get_facade()
         facade.filter(f"{field} {operator} {value}")
         graph = facade.get_active_graph()

--- a/simple-visualizer/graph/simple_plugin/templates/simple_visualizer_light.html
+++ b/simple-visualizer/graph/simple_plugin/templates/simple_visualizer_light.html
@@ -80,25 +80,29 @@
 
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
 <script type="text/javascript">
-    // ════════════════════════════════════════════════════════════════
-    // Standard Event Emission Protocol
-    // ════════════════════════════════════════════════════════════════
     window.emitVisualizerEvent = function(type, data) {
-        if (window.parent !== window) {
-            window.parent.postMessage({ 
-                type: type, 
-                data: data || {} 
-            }, '*');
+        var payload = {
+            type: type,
+            data: data || {}
+        };
+
+        try {
+            window.dispatchEvent(new CustomEvent("visualizer-event", {
+                detail: payload
+            }));
+        } catch (e) {}
+
+        if (window.parent && window.parent !== window) {
+            window.parent.postMessage(payload, "*");
         }
     };
-    
+
     function render() {
         var graphNodes = JSON.parse(document.getElementById("nodes-data").textContent);
         var graphLinks = JSON.parse(document.getElementById("edges-data").textContent);
         var nodeRadius = __NODE_RADIUS__;
         var selectedNodeId = null;
 
-        // Deep copy nodes to avoid mutation
         graphNodes = graphNodes.map(function (n) { return Object.assign({}, n); });
         graphLinks = graphLinks.map(function (e) { return Object.assign({}, e); });
 
@@ -118,8 +122,8 @@
             .scaleExtent([0.05, 8])
             .on("zoom", function (event) {
                 g.attr("transform", event.transform);
-                // Emit viewport change event using standard protocol
-                emitVisualizerEvent('viewport-change', {
+
+                emitVisualizerEvent("viewport-change", {
                     transform: {
                         x: event.transform.x,
                         y: event.transform.y,
@@ -129,6 +133,7 @@
                     height: height
                 });
             });
+
         svg.call(zoomBehavior);
 
         svg.append("defs").append("marker")
@@ -173,13 +178,24 @@
         var tooltip = d3.select("body").append("div")
             .attr("id", "node-tooltip");
 
-        node.on("mouseover", function (event, d) {
-            d3.select(this)
-                .style("fill", "#f4b942")
-                .attr("r", 18);
+        function applySelectedVisualState() {
+            node.each(function (d) {
+                var isSelected = d.id === selectedNodeId;
+                d3.select(this)
+                    .classed("selected", isSelected)
+                    .attr("fill", isSelected ? "#f4b942" : "#157a6e")
+                    .attr("r", isSelected ? 18 : 14);
+            });
+        }
 
-            // Emit node hover event using standard protocol
-            emitVisualizerEvent('node-hover', { nodeId: d.id });
+        node.on("mouseover", function (event, d) {
+            if (selectedNodeId !== d.id) {
+                d3.select(this)
+                    .attr("fill", "#f4b942")
+                    .attr("r", 18);
+            }
+
+            emitVisualizerEvent("node-hover", { nodeId: d.id });
 
             var html = '<div class="tooltip-title">Node: ' + d.id + '</div>';
             if (d.data && Object.keys(d.data).length > 0) {
@@ -196,14 +212,23 @@
                 .style("top", (event.pageY - 10) + "px");
         });
 
+        node.on("click", function (event, d) {
+            selectedNodeId = d.id;
+            applySelectedVisualState();
+
+            emitVisualizerEvent("node-select", {
+                nodeId: d.id
+            });
+        });
+
         node.on("mouseout", function (event, d) {
-            d3.select(this)
-                .style("fill", "#157a6e")
-                .attr("r", 14);
+            if (selectedNodeId !== d.id) {
+                d3.select(this)
+                    .attr("fill", "#157a6e")
+                    .attr("r", 14);
+            }
 
-            // Emit node hover end event using standard protocol
-            emitVisualizerEvent('node-hover-end', { nodeId: d.id });
-
+            emitVisualizerEvent("node-hover-end", { nodeId: d.id });
             tooltip.style("display", "none");
         });
 
@@ -235,9 +260,10 @@
         var positionEmitIntervalTicks = 15;
 
         function emitCurrentPositions(eventType) {
-            var positions = graphNodes.map(function(n) {
+            var positions = graphNodes.map(function (n) {
                 return { id: n.id, x: n.x, y: n.y };
             });
+
             emitVisualizerEvent(eventType, {
                 positions: positions,
                 links: graphLinks
@@ -248,15 +274,15 @@
             .force("link", d3.forceLink(graphLinks).id(function (d) { return d.id; }).distance(linkDistance))
             .force("charge", d3.forceManyBody().strength(chargeStrength))
             .force("center", d3.forceCenter(width / 2, height / 2))
-            .on("tick", function() {
+            .on("tick", function () {
                 ticked();
                 tickCounter++;
                 if (tickCounter % positionEmitIntervalTicks === 0) {
-                    emitCurrentPositions('visualizer-positions');
+                    emitCurrentPositions("visualizer-positions");
                 }
             })
-            .on("end", function() {
-                emitCurrentPositions('layout-complete');
+            .on("end", function () {
+                emitCurrentPositions("layout-complete");
             });
 
         node.call(d3.drag()
@@ -276,8 +302,12 @@
             })
         );
 
-        // Listen for messages from parent (standardized event protocol)
-        window.addEventListener('message', function(event) {
+        emitVisualizerEvent("graph-ready", {
+            width: width,
+            height: height
+        });
+
+        window.addEventListener("message", function (event) {
             if (!event.data || !event.data.type || !event.data.data) {
                 return;
             }
@@ -285,19 +315,19 @@
             var type = event.data.type;
             var data = event.data.data;
 
-            if (type === 'node-hover') {
-                node.each(function(d) {
-                    if (d.id === data.nodeId) {
+            if (type === "node-hover") {
+                node.each(function (d) {
+                    if (d.id === data.nodeId && d.id !== selectedNodeId) {
                         d3.select(this)
-                            .style("fill", "#f4b942")
+                            .attr("fill", "#f4b942")
                             .attr("r", 18);
                     }
                 });
-            } else if (type === 'node-hover-end') {
-                node.each(function(d) {
-                    if (d.id === data.nodeId) {
+            } else if (type === "node-hover-end") {
+                node.each(function (d) {
+                    if (d.id === data.nodeId && d.id !== selectedNodeId) {
                         d3.select(this)
-                            .style("fill", "#157a6e")
+                            .attr("fill", "#157a6e")
                             .attr("r", 14);
                     }
                 });


### PR DESCRIPTION
After applying filter/search/reset, the page was rendered as home.html but the browser URL remained on API endpoints such as /graph-explorer/api/reset/. Because the workspace forms did not define an explicit action, creating or switching workspaces submitted the request to the wrong endpoint, making the UI appear stuck on the current workspace.

Closes #48 